### PR TITLE
Add support for Clash's Modern CPU executable

### DIFF
--- a/clashN/clashN/Handler/LazyConfig.cs
+++ b/clashN/clashN/Handler/LazyConfig.cs
@@ -61,7 +61,7 @@ namespace clashN.Handler
             coreInfos.Add(new CoreInfo
             {
                 coreType = ECoreType.clash,
-                coreExes = new List<string> { "clash-windows-amd64", "clash-windows-386", "clash" },
+                coreExes = new List<string> { "clash-windows-amd64-v3", "clash-windows-amd64", "clash-windows-386", "clash" },
                 arguments = "-f config.yaml",
                 coreUrl = Global.clashCoreUrl,
                 match = "Clash"


### PR DESCRIPTION
Detect clash-windows-amd64-v3.exe