### PR TITLE
Add a tip showing when running the second ClashN

### DIFF
--- a/clashN/clashN/App.xaml.cs
+++ b/clashN/clashN/App.xaml.cs
@@ -19,10 +19,10 @@ namespace ClashN
             ProgramStarted = new EventWaitHandle(false, EventResetMode.AutoReset, "ProgramStartedEvent", out bool bCreatedNew);
             if (!bCreatedNew)
             {
-                ProgramStarted.Set();
-                App.Current.Shutdown();
+                MessageBox.Show($"ClashN is already running{Environment.NewLine}(ClashN 已在运行中)", "ClashN", MessageBoxButton.OK, MessageBoxImage.Information);
+
+                ProgramStarted.Close();
                 Environment.Exit(-1);
-                return;
             }
         }
 


### PR DESCRIPTION
1. 避免 在 App 类完成实例化之前调用 App.Current.Shutdown(); (否则会产生未捕获的异常)
2. 添加 重复启动 ClashN 时显示提示